### PR TITLE
v̧, only used in shaw-1986, is ɣ

### DIFF
--- a/etc/orthography.tsv
+++ b/etc/orthography.tsv
@@ -467,7 +467,6 @@ u′	u ʔ
 uⁱ	ui
 uⁿ	ũ
 v	v
-v̧	v
 v̲	v
 w	w
 w:	w


### PR DESCRIPTION
Shaw (1986) p. 69 uses ɣ, not v̧.
See https://openresearch-repository.anu.edu.au/server/api/core/bitstreams/2ee2b703-eddc-481c-b386-d636a14f2696/content

For example 95. mʌɣʌn instead of 95. mʌv̧ʌn.
<img width="156" alt="Screenshot 2025-06-20 at 14 58 05" src="https://github.com/user-attachments/assets/8f4f02e9-fba1-4d87-90e9-e4a33b5851b0" />
